### PR TITLE
feat: Add `showAllLeaderboards` method to display all game leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Before use the `Achievement Methods` of the plugin, you need to setup your Achie
 
 * [`signIn()`](#signin)
 * [`showLeaderboard(...)`](#showleaderboard)
+* [`showAllLeaderboards()`](#showallleaderboards)
 * [`submitScore(...)`](#submitscore)
 * [`showAchievements()`](#showachievements)
 * [`unlockAchievement(...)`](#unlockachievement)
@@ -182,6 +183,17 @@ showLeaderboard(options: { leaderboardID: string; }) => Promise<void>
 | Param         | Type                                    |
 | ------------- | --------------------------------------- |
 | **`options`** | <code>{ leaderboardID: string; }</code> |
+
+--------------------
+
+
+### showAllLeaderboards()
+
+```typescript
+showAllLeaderboards() => Promise<void>
+```
+
+* Method to display all Leaderboards
 
 --------------------
 

--- a/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnect.java
+++ b/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnect.java
@@ -99,6 +99,26 @@ public class CapacitorGameConnect {
     }
 
     /**
+     * * Method to display ALL Leaderboards from Google Play Services SDK
+     *
+     * @param startActivityIntent as ActivityResultLauncher<Intent>
+     */
+    public void showAllLeaderboards(ActivityResultLauncher<Intent> startActivityIntent) {
+        Log.i(TAG, "showAllLeaderboards has been called");
+        PlayGames
+            .getLeaderboardsClient(this.activity)
+            .getAllLeaderboardsIntent()
+            .addOnSuccessListener(
+                new OnSuccessListener<Intent>() {
+                    @Override
+                    public void onSuccess(Intent intent) {
+                        startActivityIntent.launch(intent);
+                    }
+                }
+            );
+    }
+
+    /**
      * * Method to submit a score to the Google Play Services SDK
      *
      * @param call as PluginCall

--- a/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnectPlugin.java
+++ b/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnectPlugin.java
@@ -76,6 +76,12 @@ public class CapacitorGameConnectPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void showAllLeaderboards(PluginCall call) {
+        implementation.showAllLeaderboards(this.startActivityIntent);
+        call.resolve();
+    }
+
+    @PluginMethod
     public void submitScore(PluginCall call) {
         implementation.submitScore(call);
         call.resolve();

--- a/ios/Plugin/CapacitorGameConnect.swift
+++ b/ios/Plugin/CapacitorGameConnect.swift
@@ -37,6 +37,15 @@ import Capacitor
         }
     }
         
+    @objc func showAllLeaderboards(_ call: CAPPluginCall, _ viewController: UIViewController) {
+        DispatchQueue.main.async {
+            let leaderboardViewController = GKGameCenterViewController()
+            leaderboardViewController.viewState = .leaderboards
+            leaderboardViewController.gameCenterDelegate = self
+            viewController.present(leaderboardViewController, animated: true)
+        }
+    }
+
     @objc func showAchievements(_ call: CAPPluginCall, _ viewController: UIViewController) {
         guard GKLocalPlayer.local.isAuthenticated else {
             print("Player is not authenticated")

--- a/ios/Plugin/CapacitorGameConnectPlugin.m
+++ b/ios/Plugin/CapacitorGameConnectPlugin.m
@@ -6,6 +6,7 @@
 CAP_PLUGIN(CapacitorGameConnectPlugin, "CapacitorGameConnect",
            CAP_PLUGIN_METHOD(signIn, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(showLeaderboard, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(showAllLeaderboards, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(showAchievements, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(submitScore, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(unlockAchievement, CAPPluginReturnPromise);

--- a/ios/Plugin/CapacitorGameConnectPlugin.swift
+++ b/ios/Plugin/CapacitorGameConnectPlugin.swift
@@ -20,6 +20,11 @@ public class CapacitorGameConnectPlugin: CAPPlugin {
         call.resolve()
     }
     
+    @objc func showAllLeaderboards(_ call: CAPPluginCall) {
+        implementation.showAllLeaderboards(call, (self.bridge?.viewController)!)
+        call.resolve()
+    }
+
     @objc func showAchievements(_ call: CAPPluginCall) {
         implementation.showAchievements(call, (self.bridge?.viewController)!)
         call.resolve()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,6 +19,12 @@ export interface CapacitorGameConnectPlugin {
   showLeaderboard(options: { leaderboardID: string }): Promise<void>;
 
   /**
+   * * Method to display all Leaderboards
+   *
+   */
+  showAllLeaderboards(): Promise<void>;
+
+  /**
    * * Method to submit a score to the Google Play Services SDK
    *
    */

--- a/src/web.ts
+++ b/src/web.ts
@@ -28,6 +28,16 @@ export class CapacitorGameConnectWeb
   }
 
   /**
+   * * Method to display all Leaderboards
+   *
+   * @returns Promise
+   */
+  async showAllLeaderboards(): Promise<void> {
+    console.info('showAllLeaderboards function has been called');
+    return Promise.resolve();
+  }
+
+  /**
    * * Method to submit a score to the Google Play Services SDK
    *
    * @returns Promise


### PR DESCRIPTION
Add `showAllLeaderboards()` method to display the native all-leaderboards UI on both Android and iOS