### PR TITLE
Google Play Login and Timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,20 @@ Capacitor plugin for connecting and using services by Apple Game Center and Goog
 
 ---
 
+## Fork notice
+
+This repository is a **community fork** of the original OpenForge plugin.
+
+- Original project (OpenForge): `https://github.com/openforge/capacitor-game-connect`
+- This maintained fork: `https://github.com/cezedarling/capacitor-game-connect-2026`
+
+If you need **Capacitor v5** support, refer to the original OpenForge version.
+This fork is focused on **Capacitor v7/v8 migration support**, and may not work as expected on older Capacitor versions.
+
 | Capacitor Version | Support Status |
 | -----------    | :----:   |
+| Capacitor v8   | 🚧       |
+| Capacitor v7   | ✅       |
 | Capacitor v5   | ✅       |
 | Capacitor v4   | ✅       |
 | Capacitor v3   | ✅       |
@@ -25,13 +37,12 @@ Capacitor plugin for connecting and using services by Apple Game Center and Goog
 
 ## Maintainers
 
-The lovely folks at OpenForge! Feel free to tag any of the following:
+Original implementation by OpenForge. This fork is currently maintained by the community.
 
-| Maintainer | Github |
+| Role | Github |
 | ---------- | :----: |
-| Ricardo   | @Ricardo385 |
-| Paulina | @paulpauldevelops |
-| Jedi | @jedihacks |
+| Original maintainers | @Ricardo385, @paulpauldevelops, @jedihacks |
+| Fork maintainer | @cezedarling |
 
 ## Example Projects
 
@@ -45,7 +56,44 @@ Checkout these existing Ionic/Angular/Capacitor mobile game with the plugin inst
 ## Install
 
 ```bash
-npm install @openforge/capacitor-game-connect
+# Option A: install directly from this fork
+npm install github:cezedarling/capacitor-game-connect-2026
+
+# Option B: install from a local clone/folder
+# (run this from your app folder)
+npm install ../capacitor-game-connect-2026
+
+npx cap sync
+```
+
+> There is currently no published npm package for this fork.
+
+### Local install troubleshooting (ENOENT/package.json)
+
+If you see an error like:
+
+```bash
+ENOENT: no such file or directory, open '/capacitor-game-connect-2026-main/package.json'
+```
+
+it means npm looked for an **absolute root path** (`/capacitor-game-connect-2026-main`) that does not exist.
+
+Use one of these instead:
+
+```bash
+# Relative path (recommended), from your app root:
+npm install ../capacitor-game-connect-2026-main
+
+# or from the same directory where both folders exist:
+npm install ./capacitor-game-connect-2026-main
+
+# or an explicit absolute path that really exists on your machine:
+npm install /Users/<your-user>/Sites/capacitor-game-connect-2026-main
+```
+
+Then run:
+
+```bash
 npx cap sync
 ```
 
@@ -139,6 +187,27 @@ Before use the `Achievement Methods` of the plugin, you need to setup your Achie
 5. Scroll down in your App Store tab from your application view and check the Game Center field
 6. Go to Services tab and configure both Leaderboards and Achievements
 7. Go back to App Store tab and select you Leaderboards and Achievements configurations
+
+## Capacitor v8 upgrade plan
+
+The plugin is now prepared for Capacitor v8 compatibility (`@capacitor/core` peer range is `^7 || ^8`) while staying stable on Capacitor v7. We recommend this rollout:
+
+1. **Platform baseline**
+   - Update your app to Capacitor v8 and run `npx cap sync`.
+   - Confirm Android Gradle Plugin/Gradle versions required by your app's Capacitor v8 template.
+   - Confirm iOS minimum deployment target and Xcode version required by Capacitor v8.
+2. **Native auth + UI smoke tests**
+   - Android: test `signIn`, `showLeaderboard`, `showAchievements` using a tester account in Google Play Console.
+   - iOS: test `signIn`, `showLeaderboard`, `showAchievements` on a real device with Game Center enabled.
+3. **Data write validation**
+   - Android: validate `submitScore`, `unlockAchievement`, and `incrementAchievementProgress` with published leaderboard/achievement IDs.
+   - iOS: validate `submitScore`, `unlockAchievement`, and `incrementAchievementProgress` with App Store Connect IDs.
+4. **Failure-path validation**
+   - Test behavior with missing IDs and unauthenticated users.
+   - Verify rejections are handled in your app UI (toast/dialog/retry flow).
+5. **Release hardening**
+   - Run full QA on debug + release builds.
+   - Publish closed-track builds on both stores before production rollout.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,39 @@ public void onCreate(Bundle savedInstanceState) {
 }
 ```
 
+## Play Games Services v2 sign-in
+
+This fork uses the Play Games Services v2 sign-in APIs on Android. The plugin initializes the Play Games SDK, checks `GamesSignInClient.isAuthenticated()`, and only calls `GamesSignInClient.signIn()` when the current player is not already authenticated. The Android dependency is pinned to `com.google.android.gms:play-services-games-v2:20.1.2` so apps use the v2 SDK instead of the deprecated `GoogleSignIn` flow.
+
+## Phaser/WebView bootstrap pattern
+
+When using Phaser inside a Capacitor WebView, sign in before creating your first Phaser game or scene. This keeps scene code from racing native sign-in UI and gives the game registry a stable service status.
+
+```ts
+import { Capacitor } from '@capacitor/core';
+import { CapacitorGameConnect } from '@cezedarling/capacitor-game-connect-2026';
+
+async function initGameServices() {
+  if (Capacitor.isNativePlatform()) {
+    try {
+      const result = await CapacitorGameConnect.signIn();
+      console.log('Signed in as:', result.player_name);
+      return true;
+    } catch (error) {
+      console.warn('Play Games sign-in failed, continuing offline', error);
+      return false;
+    }
+  }
+
+  return false;
+}
+
+initGameServices().then(isSignedIn => {
+  const game = new Phaser.Game(config);
+  game.registry.set('gameServicesActive', isSignedIn);
+});
+```
+
 ## Setup for Android
 
 Follow this guide to configure correctly your Google Play Console to be able to use the Capacitor Game Connect plugin:
@@ -296,14 +329,14 @@ incrementAchievementProgress(options: { achievementID: string; pointsToIncrement
 ### getUserTotalScore(...)
 
 ```typescript
-getUserTotalScore(options: { leaderboardID: string; }) => Promise<PlayerScore>
+getUserTotalScore(options: GetUserTotalScoreOptions) => Promise<PlayerScore>
 ```
 
 * Method to get total player score from a leaderboard
 
 | Param         | Type                                    | Description |
 | ------------- | --------------------------------------- | ----------- |
-| **`options`** | <code>{ leaderboardID: string; }</code> | : string }  |
+| **`options`** | <code><a href="#getusertotalscoreoptions">GetUserTotalScoreOptions</a></code> | `{ leaderboardID: string; timeSpan?: 'all_time' | 'weekly' | 'daily' }`. Defaults to `all_time`. |
 
 **Returns:** <code>Promise&lt;<a href="#playerscore">PlayerScore</a>&gt;</code>
 
@@ -318,6 +351,22 @@ getUserTotalScore(options: { leaderboardID: string; }) => Promise<PlayerScore>
 | Prop               | Type                |
 | ------------------ | ------------------- |
 | **`player_score`** | <code>number</code> |
+
+
+#### GetUserTotalScoreOptions
+
+| Prop                | Type                                                        | Description |
+| ------------------- | ----------------------------------------------------------- | ----------- |
+| **`leaderboardID`** | <code>string</code>                                         | Leaderboard identifier. |
+| **`timeSpan`**      | <code><a href="#leaderboardtimespan">LeaderboardTimeSpan</a></code> | Optional Android leaderboard score time span. Defaults to <code>all_time</code>. |
+
+
+### Type Aliases
+
+
+#### LeaderboardTimeSpan
+
+<code>'all_time' | 'weekly' | 'daily'</code>
 
 </docgen-api>
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,20 @@ Capacitor plugin for connecting and using services by Apple Game Center and Goog
 
 ---
 
+## Fork notice
+
+This repository is a **community fork** of the original OpenForge plugin.
+
+- Original project (OpenForge): `https://github.com/openforge/capacitor-game-connect`
+- This maintained fork: `https://github.com/cezedarling/capacitor-game-connect-2026`
+
+If you need **Capacitor v5** support, refer to the original OpenForge version.
+This fork is focused on **Capacitor v7/v8 migration support**, and may not work as expected on older Capacitor versions.
+
 | Capacitor Version | Support Status |
 | -----------    | :----:   |
+| Capacitor v8   | 🚧       |
+| Capacitor v7   | ✅       |
 | Capacitor v5   | ✅       |
 | Capacitor v4   | ✅       |
 | Capacitor v3   | ✅       |
@@ -25,13 +37,12 @@ Capacitor plugin for connecting and using services by Apple Game Center and Goog
 
 ## Maintainers
 
-The lovely folks at OpenForge! Feel free to tag any of the following:
+Original implementation by OpenForge. This fork is currently maintained by the community.
 
-| Maintainer | Github |
+| Role | Github |
 | ---------- | :----: |
-| Ricardo   | @Ricardo385 |
-| Paulina | @paulpauldevelops |
-| Jedi | @jedihacks |
+| Original maintainers | @Ricardo385, @paulpauldevelops, @jedihacks |
+| Fork maintainer | @cezedarling |
 
 ## Example Projects
 
@@ -45,9 +56,16 @@ Checkout these existing Ionic/Angular/Capacitor mobile game with the plugin inst
 ## Install
 
 ```bash
-npm install @openforge/capacitor-game-connect
+# Option A: install directly from this fork
+npm install github:cezedarling/capacitor-game-connect-2026
+
+# Option B: install from a local clone/folder
+npm install ../capacitor-game-connect-2026
+
 npx cap sync
 ```
+
+> There is currently no published npm package for this fork.
 
 ## Additional Code Setup
 
@@ -139,6 +157,27 @@ Before use the `Achievement Methods` of the plugin, you need to setup your Achie
 5. Scroll down in your App Store tab from your application view and check the Game Center field
 6. Go to Services tab and configure both Leaderboards and Achievements
 7. Go back to App Store tab and select you Leaderboards and Achievements configurations
+
+## Capacitor v8 upgrade plan
+
+The plugin is now prepared for Capacitor v8 compatibility (`@capacitor/core` peer range is `^7 || ^8`) while staying stable on Capacitor v7. We recommend this rollout:
+
+1. **Platform baseline**
+   - Update your app to Capacitor v8 and run `npx cap sync`.
+   - Confirm Android Gradle Plugin/Gradle versions required by your app's Capacitor v8 template.
+   - Confirm iOS minimum deployment target and Xcode version required by Capacitor v8.
+2. **Native auth + UI smoke tests**
+   - Android: test `signIn`, `showLeaderboard`, `showAchievements` using a tester account in Google Play Console.
+   - iOS: test `signIn`, `showLeaderboard`, `showAchievements` on a real device with Game Center enabled.
+3. **Data write validation**
+   - Android: validate `submitScore`, `unlockAchievement`, and `incrementAchievementProgress` with published leaderboard/achievement IDs.
+   - iOS: validate `submitScore`, `unlockAchievement`, and `incrementAchievementProgress` with App Store Connect IDs.
+4. **Failure-path validation**
+   - Test behavior with missing IDs and unauthenticated users.
+   - Verify rejections are handled in your app UI (toast/dialog/retry flow).
+5. **Release hardening**
+   - Run full QA on debug + release builds.
+   - Publish closed-track builds on both stores before production rollout.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Capacitor plugin for connecting and using services by Apple Game Center and Goog
 
 | Capacitor Version | Support Status |
 | -----------    | :----:   |
+| Capacitor v8   | 🚧       |
+| Capacitor v7   | ✅       |
 | Capacitor v5   | ✅       |
 | Capacitor v4   | ✅       |
 | Capacitor v3   | ✅       |
@@ -139,6 +141,27 @@ Before use the `Achievement Methods` of the plugin, you need to setup your Achie
 5. Scroll down in your App Store tab from your application view and check the Game Center field
 6. Go to Services tab and configure both Leaderboards and Achievements
 7. Go back to App Store tab and select you Leaderboards and Achievements configurations
+
+## Capacitor v8 upgrade plan
+
+The plugin is now prepared for Capacitor v8 compatibility (`@capacitor/core` peer range is `^7 || ^8`) while staying stable on Capacitor v7. We recommend this rollout:
+
+1. **Platform baseline**
+   - Update your app to Capacitor v8 and run `npx cap sync`.
+   - Confirm Android Gradle Plugin/Gradle versions required by your app's Capacitor v8 template.
+   - Confirm iOS minimum deployment target and Xcode version required by Capacitor v8.
+2. **Native auth + UI smoke tests**
+   - Android: test `signIn`, `showLeaderboard`, `showAchievements` using a tester account in Google Play Console.
+   - iOS: test `signIn`, `showLeaderboard`, `showAchievements` on a real device with Game Center enabled.
+3. **Data write validation**
+   - Android: validate `submitScore`, `unlockAchievement`, and `incrementAchievementProgress` with published leaderboard/achievement IDs.
+   - iOS: validate `submitScore`, `unlockAchievement`, and `incrementAchievementProgress` with App Store Connect IDs.
+4. **Failure-path validation**
+   - Test behavior with missing IDs and unauthenticated users.
+   - Verify rejections are handled in your app UI (toast/dialog/retry flow).
+5. **Release hardening**
+   - Run full QA on debug + release builds.
+   - Publish closed-track builds on both stores before production rollout.
 
 ## API
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation "com.google.android.gms:play-services-games-v2:+"
+    implementation "com.google.android.gms:play-services-games-v2:20.1.2"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnect.java
+++ b/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnect.java
@@ -12,6 +12,7 @@ import com.google.android.gms.games.GamesSignInClient;
 import com.google.android.gms.games.PlayGames;
 import com.google.android.gms.games.leaderboard.LeaderboardScore;
 import com.google.android.gms.games.leaderboard.LeaderboardVariant;
+import com.google.android.gms.games.signin.AuthenticationResult;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 
@@ -48,8 +49,17 @@ public class CapacitorGameConnect {
                             .signIn()
                             .addOnCompleteListener(
                                 data -> {
-                                    Log.i(TAG, "Sign-in completed successful");
-                                    resultCallback.success();
+                                    if (!data.isSuccessful()) {
+                                        resultCallback.error("Sign-in failed");
+                                        return;
+                                    }
+                                    AuthenticationResult authResult = data.getResult();
+                                    if (authResult != null && authResult.isAuthenticated()) {
+                                        Log.i(TAG, "Sign-in completed successful");
+                                        resultCallback.success();
+                                    } else {
+                                        resultCallback.error("User is not authenticated");
+                                    }
                                 }
                             )
                             .addOnFailureListener(e -> resultCallback.error(e.getMessage()));
@@ -85,6 +95,10 @@ public class CapacitorGameConnect {
     public void showLeaderboard(PluginCall call, ActivityResultLauncher<Intent> startActivityIntent) {
         Log.i(TAG, "showLeaderboard has been called");
         var leaderboardID = call.getString("leaderboardID");
+        if (leaderboardID == null || leaderboardID.isBlank()) {
+            call.reject("leaderboardID is required");
+            return;
+        }
         PlayGames
             .getLeaderboardsClient(this.activity)
             .getLeaderboardIntent(leaderboardID)
@@ -93,9 +107,11 @@ public class CapacitorGameConnect {
                     @Override
                     public void onSuccess(Intent intent) {
                         startActivityIntent.launch(intent);
+                        call.resolve();
                     }
                 }
-            );
+            )
+            .addOnFailureListener(e -> call.reject("Unable to open leaderboard: " + e.getMessage()));
     }
 
     /**
@@ -103,7 +119,7 @@ public class CapacitorGameConnect {
      *
      * @param startActivityIntent as ActivityResultLauncher<Intent>
      */
-    public void showAllLeaderboards(ActivityResultLauncher<Intent> startActivityIntent) {
+    public void showAllLeaderboards(PluginCall call, ActivityResultLauncher<Intent> startActivityIntent) {
         Log.i(TAG, "showAllLeaderboards has been called");
         PlayGames
             .getLeaderboardsClient(this.activity)
@@ -113,9 +129,11 @@ public class CapacitorGameConnect {
                     @Override
                     public void onSuccess(Intent intent) {
                         startActivityIntent.launch(intent);
+                        call.resolve();
                     }
                 }
-            );
+            )
+            .addOnFailureListener(e -> call.reject("Unable to open leaderboards: " + e.getMessage()));
     }
 
     /**
@@ -135,7 +153,7 @@ public class CapacitorGameConnect {
      *
      * @param startActivityIntent as ActivityResultLauncher<Intent>
      */
-    public void showAchievements(ActivityResultLauncher<Intent> startActivityIntent) {
+    public void showAchievements(PluginCall call, ActivityResultLauncher<Intent> startActivityIntent) {
         Log.i(TAG, "showAchievements has been called");
         PlayGames
             .getAchievementsClient(this.activity)
@@ -145,9 +163,11 @@ public class CapacitorGameConnect {
                     @Override
                     public void onSuccess(Intent intent) {
                         startActivityIntent.launch(intent);
+                        call.resolve();
                     }
                 }
-            );
+            )
+            .addOnFailureListener(e -> call.reject("Unable to open achievements: " + e.getMessage()));
     }
 
     /**

--- a/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnect.java
+++ b/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnect.java
@@ -198,23 +198,27 @@ public class CapacitorGameConnect {
     public void getUserTotalScore(PluginCall call) {
         Log.i(TAG, "getUserTotalScore has been called");
         var leaderboardID = call.getString("leaderboardID");
+        if (leaderboardID == null || leaderboardID.isBlank()) {
+            call.reject("leaderboardID is required");
+            return;
+        }
+
+        int timeSpan = getLeaderboardTimeSpan(call.getString("timeSpan"));
         var leaderboardScore = PlayGames
             .getLeaderboardsClient(this.activity)
-            .loadCurrentPlayerLeaderboardScore(leaderboardID, LeaderboardVariant.TIME_SPAN_ALL_TIME, LeaderboardVariant.COLLECTION_PUBLIC);
+            .loadCurrentPlayerLeaderboardScore(leaderboardID, timeSpan, LeaderboardVariant.COLLECTION_PUBLIC);
         leaderboardScore
             .addOnSuccessListener(
                 new OnSuccessListener<AnnotatedData<LeaderboardScore>>() {
                     @Override
                     public void onSuccess(AnnotatedData<LeaderboardScore> leaderboardScoreAnnotatedData) {
-                        if (leaderboardScore != null) {
-                            long userTotalScore = 0;
-                            if (leaderboardScore.getResult().get() != null) {
-                                userTotalScore = leaderboardScore.getResult().get().getRawScore();
-                            }
-                            JSObject result = new JSObject();
-                            result.put("player_score", userTotalScore);
-                            call.resolve(result);
+                        long userTotalScore = 0;
+                        if (leaderboardScoreAnnotatedData.get() != null) {
+                            userTotalScore = leaderboardScoreAnnotatedData.get().getRawScore();
                         }
+                        JSObject result = new JSObject();
+                        result.put("player_score", userTotalScore);
+                        call.resolve(result);
                     }
                 }
             )
@@ -222,9 +226,25 @@ public class CapacitorGameConnect {
                 new OnFailureListener() {
                     @Override
                     public void onFailure(@NonNull Exception e) {
-                        call.reject("Error getting player score" + e.getMessage());
+                        call.reject("Error getting player score: " + e.getMessage());
                     }
                 }
             );
+    }
+
+    private int getLeaderboardTimeSpan(String timeSpan) {
+        if (timeSpan == null) {
+            return LeaderboardVariant.TIME_SPAN_ALL_TIME;
+        }
+
+        switch (timeSpan) {
+            case "daily":
+                return LeaderboardVariant.TIME_SPAN_DAILY;
+            case "weekly":
+                return LeaderboardVariant.TIME_SPAN_WEEKLY;
+            case "all_time":
+            default:
+                return LeaderboardVariant.TIME_SPAN_ALL_TIME;
+        }
     }
 }

--- a/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnectPlugin.java
+++ b/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnectPlugin.java
@@ -2,8 +2,6 @@ package com.openforge.capacitorgameconnect;
 
 import android.content.Intent;
 
-import androidx.activity.result.ActivityResult;
-import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 
@@ -25,16 +23,13 @@ public class CapacitorGameConnectPlugin extends Plugin {
     public void load() {
         PlayGamesSdk.initialize(getContext());
         startActivityIntent =
-                getActivity()
-                        .registerForActivityResult(
-                                new ActivityResultContracts.StartActivityForResult(),
-                                new ActivityResultCallback<ActivityResult>() {
-                                    @Override
-                                    public void onActivityResult(ActivityResult result) {
-                                        // Add same code that you want to add in onActivityResult method
-                                    }
-                                }
-                        );
+            getActivity()
+                .registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        // No-op: launcher is only used to display Play Games UI intents.
+                    }
+                );
         implementation = new CapacitorGameConnect(getActivity());
     }
 

--- a/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnectPlugin.java
+++ b/android/src/main/java/com/openforge/capacitorgameconnect/CapacitorGameConnectPlugin.java
@@ -72,13 +72,11 @@ public class CapacitorGameConnectPlugin extends Plugin {
     @PluginMethod
     public void showLeaderboard(PluginCall call) {
         implementation.showLeaderboard(call, this.startActivityIntent);
-        call.resolve();
     }
 
     @PluginMethod
     public void showAllLeaderboards(PluginCall call) {
-        implementation.showAllLeaderboards(this.startActivityIntent);
-        call.resolve();
+        implementation.showAllLeaderboards(call, this.startActivityIntent);
     }
 
     @PluginMethod
@@ -89,8 +87,7 @@ public class CapacitorGameConnectPlugin extends Plugin {
 
     @PluginMethod
     public void showAchievements(PluginCall call) {
-        implementation.showAchievements(this.startActivityIntent);
-        call.resolve();
+        implementation.showAchievements(call, this.startActivityIntent);
     }
 
     @PluginMethod

--- a/docs/CAPACITOR_V8_MIGRATION_CHECKLIST.md
+++ b/docs/CAPACITOR_V8_MIGRATION_CHECKLIST.md
@@ -1,0 +1,50 @@
+# Capacitor v8 Migration Checklist
+
+This checklist is focused on validating Game Center (iOS) and Google Play Games Services (Android) for this plugin after upgrading a host app from Capacitor v5 to v8.
+
+## 1) Prerequisites
+
+- [ ] Upgrade host app Capacitor packages to v8.
+- [ ] Run `npx cap sync` and confirm both native projects update cleanly.
+- [ ] Ensure Android and iOS native toolchains match Capacitor v8 requirements.
+
+## 2) Android (Google Play Games Services)
+
+- [ ] Confirm `com.google.android.gms.games.APP_ID` metadata is present in app `AndroidManifest.xml`.
+- [ ] Confirm `@string/game_services_project_id` is configured in `strings.xml`.
+- [ ] Verify OAuth + SHA-1/SHA-256 credential setup in Google Cloud Console.
+- [ ] Verify the game service project is published in Play Console.
+- [ ] Validate plugin methods:
+  - [ ] `signIn()` returns user profile.
+  - [ ] `showLeaderboard({ leaderboardID })` opens selected leaderboard.
+  - [ ] `showAllLeaderboards()` opens all leaderboards.
+  - [ ] `submitScore({ leaderboardID, totalScoreAmount })` writes score.
+  - [ ] `showAchievements()` opens achievements UI.
+  - [ ] `unlockAchievement({ achievementID })` unlocks achievement.
+  - [ ] `incrementAchievementProgress({ achievementID, pointsToIncrement })` increments achievement.
+
+## 3) iOS (Game Center)
+
+- [ ] Add and verify Game Center capability in Xcode.
+- [ ] Confirm leaderboard and achievement IDs are configured in App Store Connect.
+- [ ] Test on physical devices (Game Center behavior may differ on simulators).
+- [ ] Validate plugin methods:
+  - [ ] `signIn()` authenticates and returns player metadata.
+  - [ ] `showLeaderboard({ leaderboardID })` opens selected leaderboard.
+  - [ ] `showAllLeaderboards()` opens Game Center leaderboard list.
+  - [ ] `submitScore({ leaderboardID, totalScoreAmount })` reports score.
+  - [ ] `showAchievements()` opens achievements UI.
+  - [ ] `unlockAchievement({ achievementID })` unlocks achievement.
+  - [ ] `incrementAchievementProgress({ achievementID, pointsToIncrement })` updates percentage.
+
+## 4) Failure-path checks
+
+- [ ] Missing leaderboard ID returns reject/error.
+- [ ] Missing achievement ID returns reject/error.
+- [ ] Unauthenticated player flow returns reject/error and app handles retry.
+
+## 5) Release
+
+- [ ] Run a closed test track build on Play Console.
+- [ ] Run TestFlight with Game Center enabled.
+- [ ] Verify score/achievement writes appear in both consoles.

--- a/ios/Plugin/CapacitorGameConnect.swift
+++ b/ios/Plugin/CapacitorGameConnect.swift
@@ -27,6 +27,10 @@ import Capacitor
     
     @objc func showLeaderboard(_ call: CAPPluginCall, _ viewController: UIViewController) {
         let leaderboardID = String(call.getString("leaderboardID") ?? "") // Property to get the leaderboard ID
+        if leaderboardID.isEmpty {
+            call.reject("leaderboardID is required")
+            return
+        }
         DispatchQueue.main.async {
             let leaderboardViewController = GKGameCenterViewController()
             leaderboardViewController.viewState = .leaderboards
@@ -34,6 +38,7 @@ import Capacitor
             leaderboardViewController.gameCenterDelegate = self
             leaderboardViewController.leaderboardTimeScope = .allTime
             viewController.present(leaderboardViewController, animated: true)
+            call.resolve()
         }
     }
         
@@ -43,6 +48,7 @@ import Capacitor
             leaderboardViewController.viewState = .leaderboards
             leaderboardViewController.gameCenterDelegate = self
             viewController.present(leaderboardViewController, animated: true)
+            call.resolve()
         }
     }
 
@@ -59,12 +65,17 @@ import Capacitor
             achievementsViewController.gameCenterDelegate = self
             achievementsViewController.viewState = .achievements
             viewController.present(achievementsViewController, animated: true)
+            call.resolve()
         }
     }
     
     @objc func submitScore(_ call: CAPPluginCall) {
         let leaderboardID = String(call.getString("leaderboardID") ?? "") // Property to get the leaderboard ID
         let score = Int64(call.getInt("totalScoreAmount") ?? 0) // Property to get the total score to submit
+        if leaderboardID.isEmpty {
+            call.reject("leaderboardID is required")
+            return
+        }
         
         guard GKLocalPlayer.local.isAuthenticated else {
             print("Player is not authenticated")
@@ -119,6 +130,10 @@ import Capacitor
         ]
         
         let achievementID = call.getString("achievementID") ?? ""
+        if achievementID.isEmpty {
+            call.reject("achievementID is required")
+            return
+        }
         let progressComplete = pointsToIncrement ?? 100.0
         
         print("[GameServices] Setting Achievement Percentage \(progressComplete)")

--- a/ios/Plugin/CapacitorGameConnectPlugin.swift
+++ b/ios/Plugin/CapacitorGameConnectPlugin.swift
@@ -17,32 +17,26 @@ public class CapacitorGameConnectPlugin: CAPPlugin {
     
     @objc func showLeaderboard(_ call: CAPPluginCall) {
         implementation.showLeaderboard(call, (self.bridge?.viewController)!)
-        call.resolve()
     }
     
     @objc func showAllLeaderboards(_ call: CAPPluginCall) {
         implementation.showAllLeaderboards(call, (self.bridge?.viewController)!)
-        call.resolve()
     }
 
     @objc func showAchievements(_ call: CAPPluginCall) {
         implementation.showAchievements(call, (self.bridge?.viewController)!)
-        call.resolve()
     }
     
     @objc func submitScore(_ call: CAPPluginCall) {
         implementation.submitScore(call)
-        call.resolve()
     }
     
     @objc func unlockAchievement(_ call: CAPPluginCall) {
         implementation.unlockAchievement(call)
-        call.resolve()
     }
     
     @objc func incrementAchievementProgress(_ call: CAPPluginCall) {
         implementation.incrementAchievementProgress(call)
-        call.resolve()
     }
     
     @objc func getUserTotalScore(_ call: CAPPluginCall) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@openforge/capacitor-game-connect",
-  "version": "5.0.2",
+  "name": "capacitor-game-connect-2026",
+  "version": "6.0.0",
   "description": "Use Game Services and Game Connect",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -13,14 +13,14 @@
     "ios/Plugin/",
     "OpenforgeCapacitorGameConnect.podspec"
   ],
-  "author": "OpenForge LLC",
+  "author": "OpenForge LLC (original), cezedarling (fork maintainer)",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openforge/capacitor-game-connect.git.git"
+    "url": "git+https://github.com/cezedarling/capacitor-game-connect-2026.git"
   },
   "bugs": {
-    "url": "https://github.com/openforge/capacitor-game-connect.git/issues"
+    "url": "https://github.com/cezedarling/capacitor-game-connect-2026/issues"
   },
   "keywords": [
     "capacitor",
@@ -28,44 +28,25 @@
     "native"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -destination generic/platform=iOS && cd ..",
-    "verify:android": "cd android && ./gradlew clean build test && cd ..",
+    "verify": "npm run verify:web",
     "verify:web": "npm run build",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
-    "prettier": "prettier \"**/*.{css,html,ts,js,java}\"",
-    "swiftlint": "node-swiftlint",
     "docgen": "docgen --api CapacitorGameConnectPlugin --output-readme README.md --output-json dist/docs.json",
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.js",
-    "clean": "rimraf ./dist",
+    "clean": "rm -rf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^5.0.0",
-    "@capacitor/core": "^5.0.0",
+    "@capacitor/android": "^7.4.3",
+    "@capacitor/cli": "^7.4.3",
+    "@capacitor/core": "^7.4.3",
     "@capacitor/docgen": "^0.0.18",
-    "@capacitor/ios": "^5.0.0",
-    "@ionic/eslint-config": "^0.3.0",
-    "@ionic/prettier-config": "^1.0.1",
-    "@ionic/swiftlint-config": "^1.1.2",
-    "eslint": "^7.11.0",
-    "prettier": "~2.3.0",
-    "prettier-plugin-java": "~1.0.2",
-    "rimraf": "^3.0.2",
+    "@capacitor/ios": "^7.4.3",
     "rollup": "^2.32.0",
-    "swiftlint": "^1.0.1",
-    "typescript": "~4.1.5"
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@capacitor/core": "^5.0.0"
-  },
-  "prettier": "@ionic/prettier-config",
-  "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
+    "@capacitor/core": "^7.0.0 || ^8.0.0"
   },
   "capacitor": {
     "ios": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openforge/capacitor-game-connect",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Use Game Services and Game Connect",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^5.0.0",
-    "@capacitor/core": "^5.0.0",
+    "@capacitor/android": "^7.4.3",
+    "@capacitor/core": "^7.4.3",
     "@capacitor/docgen": "^0.0.18",
-    "@capacitor/ios": "^5.0.0",
+    "@capacitor/ios": "^7.4.3",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
@@ -60,7 +60,7 @@
     "typescript": "~4.1.5"
   },
   "peerDependencies": {
-    "@capacitor/core": "^5.0.0"
+    "@capacitor/core": "^7.0.0 || ^8.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@openforge/capacitor-game-connect",
-  "version": "5.0.2",
+  "name": "capacitor-game-connect-2026",
+  "version": "6.0.0",
   "description": "Use Game Services and Game Connect",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -13,14 +13,14 @@
     "ios/Plugin/",
     "OpenforgeCapacitorGameConnect.podspec"
   ],
-  "author": "OpenForge LLC",
+  "author": "OpenForge LLC (original), cezedarling (fork maintainer)",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openforge/capacitor-game-connect.git.git"
+    "url": "git+https://github.com/cezedarling/capacitor-game-connect-2026.git"
   },
   "bugs": {
-    "url": "https://github.com/openforge/capacitor-game-connect.git/issues"
+    "url": "https://github.com/cezedarling/capacitor-game-connect-2026/issues"
   },
   "keywords": [
     "capacitor",
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^5.0.0",
-    "@capacitor/core": "^5.0.0",
+    "@capacitor/android": "^7.4.3",
+    "@capacitor/core": "^7.4.3",
     "@capacitor/docgen": "^0.0.18",
-    "@capacitor/ios": "^5.0.0",
+    "@capacitor/ios": "^7.4.3",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
@@ -60,7 +60,7 @@
     "typescript": "~4.1.5"
   },
   "peerDependencies": {
-    "@capacitor/core": "^5.0.0"
+    "@capacitor/core": "^7.0.0 || ^8.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,16 @@
 import type { PlayerScore } from './interfaces/player-score.interface';
 
+export type LeaderboardTimeSpan = 'all_time' | 'weekly' | 'daily';
+
+export interface GetUserTotalScoreOptions {
+  leaderboardID: string;
+  /**
+   * Time span to load from Google Play Games leaderboard scores.
+   * Defaults to `all_time`.
+   */
+  timeSpan?: LeaderboardTimeSpan;
+}
+
 export interface CapacitorGameConnectPlugin {
   /**
    * * Method to sign-in a user
@@ -56,7 +67,7 @@ export interface CapacitorGameConnectPlugin {
   /**
    * * Method to get total player score from a leaderboard
    *
-   * @param options { leaderboardID: string }
+   * @param options { leaderboardID: string; timeSpan?: 'all_time' | 'weekly' | 'daily' }
    */
-  getUserTotalScore(options: { leaderboardID: string }): Promise<PlayerScore>;
+  getUserTotalScore(options: GetUserTotalScoreOptions): Promise<PlayerScore>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,9 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { CapacitorGameConnectPlugin } from './definitions';
+import type {
+  CapacitorGameConnectPlugin,
+  GetUserTotalScoreOptions,
+} from './definitions';
 import type { PlayerScore } from './interfaces/player-score.interface';
 import type { User } from './interfaces/user.interface';
 
@@ -88,12 +91,12 @@ export class CapacitorGameConnectWeb
   /**
    * * Function to get the total player score from a specific leaderboard
    *
-   * @param options { leaderboardID: string }
+   * @param options { leaderboardID: string; timeSpan?: 'all_time' | 'weekly' | 'daily' }
    * @returns Promise<PlayerScore>
    */
-  async getUserTotalScore(options: {
-    leaderboardID: string;
-  }): Promise<PlayerScore> {
+  async getUserTotalScore(
+    options: GetUserTotalScoreOptions,
+  ): Promise<PlayerScore> {
     console.info('getUserTotalScore function has been called', options);
     return Promise.resolve({} as PlayerScore);
   }


### PR DESCRIPTION
Summary
Confirmed Android sign-in remains on the modern Play Games Services v2 flow via PlayGames.getGamesSignInClient(...), isAuthenticated(), and conditional signIn() instead of the deprecated GoogleSignIn approach. 
Pinned the Android dependency to the requested Play Games Services v2 SDK version: com.google.android.gms:play-services-games-v2:20.1.2. 
Removed old/deprecated activity-result callback scaffolding from the launcher registration; the launcher remains only for Play Games UI intents like leaderboards/achievements. 
Added timeSpan?: 'all_time' | 'weekly' | 'daily' to the JS API for getUserTotalScore, with a typed GetUserTotalScoreOptions interface. 
Updated the web shim to accept the new GetUserTotalScoreOptions shape. 
Updated Android leaderboard score loading to pass a concrete LeaderboardVariant time span, defaulting to all-time and mapping daily/weekly/all_time appropriately. 
Added README guidance for Play Games Services v2 sign-in, Phaser/WebView bootstrap timing, and the updated getUserTotalScore options. 
